### PR TITLE
minted works on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,10 @@ before_install:
      texlive-publishers
      texlive-humanities
      python-pygments
+     texlive-oberdiek
+     texlive-fancyvrb
+     texlive-float
+     texlive-ifplatform
+     texlive-etoolbox
+     texlive-xstring
+     texlive-lineno

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,3 @@ before_install:
      texlive-publishers
      texlive-humanities
      python-pygments
-     texlive-oberdiek
-     texlive-fancyvrb
-     texlive-float
-     texlive-ifplatform
-     texlive-etoolbox
-     texlive-xstring
-     texlive-lineno
-     texlive-minted

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,4 @@ before_install:
      texlive-etoolbox
      texlive-xstring
      texlive-lineno
+     texlive-minted

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_install:
      texlive-xetex
      texlive-publishers
      texlive-humanities
-     python3-pygments
+     python-pygments

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 default: paper
 	
 paper:
-	pdflatex  -shell-escape clusterlensing
+	pdflatex  --shell-escape clusterlensing
 	bibtex clusterlensing
-	pdflatex  -shell-escape clusterlensing
-	pdflatex  -shell-escape clusterlensing
-	pdflatex  -shell-escape clusterlensing
+	pdflatex  --shell-escape clusterlensing
+	pdflatex  --shell-escape clusterlensing
+	pdflatex  --shell-escape clusterlensing
 
 clean:
 		rm -f *.log

--- a/clusterlensing.tex
+++ b/clusterlensing.tex
@@ -423,6 +423,7 @@ The \code{ClusterEnsemble()} class creates, modifies and tracks a Pandas DataFra
 %----------------------------
 
 The above examples also demonstrate that cluster masses are converted to concentrations and to characteristic halo overdensities. This assumes the default mass-concentration relation of the \code{c_DuttonMaccio()} form, or the user can instead specify another of the relations by setting the keyword \code{cm="Prada"} or \code{cm="Duffy"}, when the \code{ClusterEnsemble()} object is instantiated. Cosmology can also be specified upon instantiation, by setting the \code{cosmology} keyword to be any \code{astropy.cosmology} object that has an \code{h} and a \code{Om0} attribute. If not specified explicitly, the default cosmological model used is \code{astropy.cosmology.Planck13}. Here is an example of creating a \code{ClusterEnsemble()} object that uses the WMAP5 cosmology \citep{WMAP5} and the \citet{Duffy08} concentration:
+\newpage
 %---------- code ----------
 \begin{minted}{python}
 >>> from astropy.cosmology import WMAP5 as cosmo
@@ -665,7 +666,7 @@ If we had made a stacked measurement of the shear or magnification profile of th
 \end{figure}
 
 Finally, we may want to investigate whether cluster miscentering has a significant effect on our sample. We would calculate the miscentered profiles, given in \cref{f3}, which could be compared to the centered profiles in \cref{f2} to see which is a better fit to our measurement. Below we will assume that the miscentering offset distribution peaks at 0.1 Mpc.
-
+\newpage
 %---------- code ----------
 \begin{minted}{python}
 

--- a/clusterlensing.tex
+++ b/clusterlensing.tex
@@ -7,22 +7,14 @@
 %\setlist{nolistsep} %really really no itemsep
 
 \usepackage{cleveref}
-\crefname{listing}{Sample Code}{Sample Codes}
 \crefname{figure}{Figure}{Figures}
 
-\usepackage{newfloat}
-
-\usepackage[newfloat]{minted}
+\usepackage{minted}
 %\usemintedstyle{trac}
 \setminted{fontsize=\footnotesize,
 		frame=lines,
 		framesep=2mm,
 		baselinestretch=1.1}
-\SetupFloatingEnvironment{listing}{name=Sample Code}
-%\SetupFloatingEnvironment{listing}{listname=List of Program Code}
-
-\PrepareListOf{listing}{\renewcommand{\cftfigpresnum}{Listing~}}
-
 
 \usepackage{listings}
 \lstdefinestyle{codeintext}{language=Python, basicstyle=\ttfamily} %normal size font for in text
@@ -374,34 +366,7 @@ Both input and output are dimensionless here. For example, to convert a concentr
 8694.8101906193315
 \end{minted}
 %----------------------------
-%---------- code ----------
-\begin{listing*}
-\begin{minted}{python}
->>> from clusterlensing import ClusterEnsemble
->>> z = [0.1,0.2,0.3]
->>> c = ClusterEnsemble(z)
->>> n200 = [20, 20, 20]
->>> c.n200 = n200
->>> 
->>> # display cluster dataframe
->>> c.dataframe
-     z  n200          m200      r200      c200       delta_c        rs
-0  0.1    20  2.700000e+13  0.612222  5.839934  12421.201995  0.104834
-1  0.2    20  2.700000e+13  0.591082  5.644512  11480.644557  0.104718
-2  0.3    20  2.700000e+13  0.569474  5.442457  10555.781440  0.104636
->>> 
->>> # specify mass directly
->>> c.m200 = [1e13, 1e14, 1e15]
->>> c.dataframe
-     z        n200          m200      r200      c200       delta_c        rs
-0  0.1    9.838141  1.000000e+13  0.439664  6.439529  15599.114356  0.068276
-1  0.2   50.956400  1.000000e+14  0.914520  4.979102   8612.362538  0.183672
-2  0.3  263.927382  1.000000e+15  1.898248  3.886853   4947.982895  0.488377
-\end{minted}
-\caption{Creating a \code{dataframe} of cluster attributes with \code{ClusterEnsemble()}. Altering the mass attribute \code{m200} propagates to other dependent variables.}
-\label{m2df}
-\end{listing*}
-%----------------------------
+
 The pair of functions \code{mass_to_richness()} and \code{richness_to_mass()}, as their names imply, perform conversions between cluster mass and richness. The only required input parameter to \code{mass_to_richness()} is the \code{mass}, and likewise the only required input to \code{richness_to_mass()} is \code{richness}. The calculations assume a power-law form for the relationship between these variables, {\bf which is a common simple choice for this scaling relation \citep[e.g.][]{Johnston07, Mandelbaum08b, Andreon10}}:\footnote{\bf Note that the factor of 20 is arbitrary, but allows for a straightforward interpretation of $M_0$ as the mass of cluster with richness 20.}
 \begin{equation}\label{massrich}
 M_{200} = M_0 \left( \frac{N_{200}}{20} \right) ^ \beta.
@@ -422,58 +387,96 @@ Here $M_0$ is the normalization, which defaults to $2.7 \times 10^{13}$, but can
 \end{minted}
 %----------------------------
 
+The \code{ClusterEnsemble()} class creates, modifies and tracks a Pandas DataFrame containing the properties and attributes of many galaxy clusters at once. When given a new or updated cluster property, it calculates and updates all dependent cluster properties, treating each cluster (row) in the DataFrame as an individual object. This makes it easy to calculate the $\Sigma(R)$ and $\Delta\Sigma(R)$ weak lensing profiles for many different mass clusters at different redshifts, with a single command. In contrast to using the \code{SurfaceMassDensity()} class discussed in Section \ref{nfw}, the user only needs to specify the cluster redshifts and either of the mass or richness. If richness is supplied, then mass is calculated from it, assuming the form of Equation \ref{massrich} (which is customizable); if mass is specified instead, than the inverse relation is used to calculate richness. In either case the changes are propagated to any dependent variables.
 
-The \code{ClusterEnsemble()} class creates, modifies and tracks a Pandas DataFrame containing the properties and attributes of many galaxy clusters at once. When given a new or updated cluster property, it calculates and updates all dependent cluster properties, treating each cluster (row) in the DataFrame as an individual object. This makes it easy to calculate the $\Sigma(R)$ and $\Delta\Sigma(R)$ weak lensing profiles for many different mass clusters at different redshifts, with a single command. In contrast to using the \code{SurfaceMassDensity()} class discussed in Section \ref{nfw}, the user only needs to specify the cluster redshifts and either of the mass or richness. If richness is supplied, then mass is calculated from it, assuming the form of Equation \ref{massrich} (which is customizable); if mass is specified instead, than the inverse relation is used to calculate richness. In either case the changes are propagated to any dependent variables, {\bf as shown in \cref{m2df}}.
-
-
-{\bf This last example (\cref{m2df})} demonstrates that cluster masses are converted to concentrations and to characteristic halo overdensities. This assumes the default mass-concentration relation of the \code{c_DuttonMaccio()} form, or the user can instead specify another of the relations by setting the keyword \code{cm="Prada"} or \code{cm="Duffy"}, when the \code{ClusterEnsemble()} object is instantiated. Cosmology can also be specified upon instantiation, by setting the \code{cosmology} keyword to be any \code{astropy.cosmology} object that has an \code{h} and a \code{Om0} attribute. If not specified explicitly, the default cosmological model used is \code{astropy.cosmology.Planck13}. {\bf \cref{options2df} gives} an example of creating a \code{ClusterEnsemble()} object that uses the WMAP5 cosmology \citep{WMAP5} and the \citet{Duffy08} concentration.
 %---------- code ----------
-\begin{listing*}
+\begin{minted}{python}
+>>> from clusterlensing import ClusterEnsemble
+>>> z = [0.1,0.2,0.3]
+>>> c = ClusterEnsemble(z)
+>>> n200 = [20, 20, 20]
+>>> c.n200 = n200
+>>> 
+>>> # display cluster dataframe
+>>> c.dataframe
+     z  n200          m200      r200      c200
+         delta_c        rs
+0  0.1    20  2.700000e+13  0.612222  5.839934
+    12421.201995  0.104834
+1  0.2    20  2.700000e+13  0.591082  5.644512
+    11480.644557  0.104718
+2  0.3    20  2.700000e+13  0.569474  5.442457
+    10555.781440  0.104636
+>>> 
+>>> # specify mass directly
+>>> c.m200 = [1e13, 1e14, 1e15]
+>>> c.dataframe
+     z        n200          m200      r200      c200
+         delta_c        rs
+0  0.1    9.838141  1.000000e+13  0.439664  6.439529
+    15599.114356  0.068276
+1  0.2   50.956400  1.000000e+14  0.914520  4.979102
+     8612.362538  0.183672
+2  0.3  263.927382  1.000000e+15  1.898248  3.886853
+     4947.982895  0.488377
+\end{minted}
+%----------------------------
+
+The above examples also demonstrate that cluster masses are converted to concentrations and to characteristic halo overdensities. This assumes the default mass-concentration relation of the \code{c_DuttonMaccio()} form, or the user can instead specify another of the relations by setting the keyword \code{cm="Prada"} or \code{cm="Duffy"}, when the \code{ClusterEnsemble()} object is instantiated. Cosmology can also be specified upon instantiation, by setting the \code{cosmology} keyword to be any \code{astropy.cosmology} object that has an \code{h} and a \code{Om0} attribute. If not specified explicitly, the default cosmological model used is \code{astropy.cosmology.Planck13}. Here is an example of creating a \code{ClusterEnsemble()} object that uses the WMAP5 cosmology \citep{WMAP5} and the \citet{Duffy08} concentration:
+%---------- code ----------
 \begin{minted}{python}
 >>> from astropy.cosmology import WMAP5 as cosmo
 >>> c = ClusterEnsemble(z, cm="Duffy",
 >>>                     cosmology=cosmo)
 >>> c.n200 = [20, 30, 40]
 >>> c.dataframe
-     z  n200          m200      r200      c200      delta_c        rs
-0  0.1    20  2.700000e+13  0.599910  4.520029  6920.955951  0.132723
-1  0.2    30  4.763120e+13  0.702040  4.136873  5678.897592  0.169703
-2  0.3    40  7.125343e+13  0.775889  3.851601  4849.836498  0.201446
+     z  n200          m200      r200      c200
+         delta_c        rs
+0  0.1    20  2.700000e+13  0.599910  4.520029
+     6920.955951  0.132723
+1  0.2    30  4.763120e+13  0.702040  4.136873
+     5678.897592  0.169703
+2  0.3    40  7.125343e+13  0.775889  3.851601
+     4849.836498  0.201446
 \end{minted}
-\caption{Example of different options that can be passed to \code{ClusterEnsemble()}, specifying cosmology and mass-concentration relationships.}
-\label{options2df}
-\end{listing*}
 %----------------------------
 
-Instead of using the \code{dataframe} attribute, which retrieves the Pandas DataFrame object itself, it might be useful to use the \code{show()} method, which prints additional information to the screen, including assumptions of the mass-richness relation. {\bf \cref{mn2df}} demonstrates how the slope or normalization of the mass-richness relation can be altered, and the changes propagate from richness through to mass and other variables.
-%---------- code ----------
-\begin{listing*}
+Instead of using the \code{dataframe} attribute, which retrieves the Pandas DataFrame object itself, it might be useful to use the \code{show()} method, which prints additional information to the screen, including assumptions of the mass-richness relation:%---------- code ----------
 \begin{minted}{python}
 >>> c.show()
 
 Cluster Ensemble:
 
-     z  n200          m200      r200      c200      delta_c        rs
+     z  n200          m200      r200      c200
+         delta_c        rs
 
-0  0.1    20  2.700000e+13  0.599910  4.520029  6920.955951  0.132723
-1  0.2    30  4.763120e+13  0.702040  4.136873  5678.897592  0.169703
-2  0.3    40  7.125343e+13  0.775889  3.851601  4849.836498  0.201446
+0  0.1    20  2.700000e+13  0.599910  4.520029
+     6920.955951  0.132723
+1  0.2    30  4.763120e+13  0.702040  4.136873
+     5678.897592  0.169703
+2  0.3    40  7.125343e+13  0.775889  3.851601
+     4849.836498  0.201446
 
 Mass-Richness Power Law:
 M200 = norm * (N200 / 20) ^ slope
    norm: 2.7e+13 solMass
    slope: 1.4
 
->>> # update the mass-richness parameters and show the resulting table
+>>> # update the mass-richness parameters
+>>> # and show the resulting table
 >>> c.massrich_norm = 3e13
 >>> c.massrich_slope = 1.5
 >>> c.show()
 
 Cluster Ensemble:
-     z  n200          m200      r200      c200      delta_c        rs
-0  0.1    20  3.000000e+13  0.621353  4.480202  6784.805438  0.138689
-1  0.2    30  5.511352e+13  0.737028  4.086481  5526.615129  0.180358
-2  0.3    40  8.485281e+13  0.822406  3.795500  4696.109606  0.216679
+     z  n200          m200      r200      c200
+         delta_c        rs
+0  0.1    20  3.000000e+13  0.621353  4.480202
+  6784.805438  0.138689
+1  0.2    30  5.511352e+13  0.737028  4.086481
+  5526.615129  0.180358
+2  0.3    40  8.485281e+13  0.822406  3.795500
+  4696.109606  0.216679
 
 Mass-Richness Power Law:
 M200 = norm * (N200 / 20) ^ slope
@@ -481,11 +484,8 @@ M200 = norm * (N200 / 20) ^ slope
    slope: 1.5
 
 \end{minted}
-\caption{Example invoking the \code{show()} method, which prints useful information in addition to the dataframe, as well as altering the parameters of the mass-richness relationship.}
-\label{mn2df}
-\end{listing*}
 %----------------------------
-
+The last example also demonstrates how the slope or normalization of the mass-richness relation can be altered, and the changes propagate from richness through to mass and other variables.
 
 Then all the ingredients are in place to calculate halo profiles by invoking the \code{calc_nfw()} method, which interfaces to the \code{sigma_nfw()} and \code{deltasigma_nfw()} methods of the \code{SurfaceMassDensity()} class, and passes it the required inputs $\{ r_s, \rho_{crit}, \delta_c \}$ for all the clusters behind the scenes. The value of $\rho_{crit}$ is calculated at every cluster redshift using the (default \code{astropy.cosmology.Planck13} or user-specified) cosmological model. The user must specify the desired radial bins \code{rbins} in Mpc.
 %---------- code ----------
@@ -540,7 +540,60 @@ Although \code{SurfaceMassDensity()} from the \code{nfw} module, and \code{Clust
 
 \section{Example}
 \label{ex}
-As an example use case, we take the Canada-France-Hawaii Telescope Lensing Survey \citep[CFHTLenS;][]{Heymans12, Erben13} public galaxy cluster catalog, which is available on Zenodo\footnote{\url{http://dx.doi.org/10.5281/zenodo.51291}} \citep{3DMFcatalog}. This dataset was previously explored using a pre-release version of the \code{cluster-lensing} software in \citet{Ford14, Ford15}. The W1 field of this survey contains 10,745 galaxy cluster candidates in the redshift range $0.2 \le z \le 0.9$, {\bf as shown in \cref{3dmf2df}.} We select a subset of the lower redshift clusters that were detected at high significance. Then we import \code{clusterlensing} to create a dataframe of the cluster properties, of which we just print the first several, and calculate the NFW profiles.
+As an example use case, we take the Canada-France-Hawaii Telescope Lensing Survey \citep[CFHTLenS;][]{Heymans12, Erben13} public galaxy cluster catalog, which is available on Zenodo\footnote{\url{http://dx.doi.org/10.5281/zenodo.51291}} \citep{3DMFcatalog}. This dataset was previously explored using a pre-release version of the \code{cluster-lensing} software in \citet{Ford14, Ford15}. The W1 field of this survey contains 10,745 galaxy cluster candidates in the redshift range $0.2 \le z \le 0.9$:
+%---------- code ----------
+\begin{minted}{python}
+>>> import numpy as np
+>>> data = np.loadtxt("Clusters_W1.dat")
+>>> data.shape
+(10745, 5)
+>>> data[0:4, :]  # print first 4 clusters
+array([[ 34.8023, -7.01005, 0.3, 4.435, 10.],
+       [ 34.9425, -7.38996, 0.5, 4.545, 21.],
+       [ 34.8651, -6.69449, 0.5, 3.858, 6.],
+       [ 34.6224, -7.32768, 0.5, 3.619, 8.]])
+>>>
+>>> redshift = data[:, 2]
+>>> sig = data[:, 3]
+>>> richness = data[:, 4]
+\end{minted}
+%----------------------------
+
+We select a subset of the lower redshift clusters that were detected at high significance. Then we import \code{clusterlensing} to create a dataframe of the cluster properties, of which we just print the first several, and calculate the NFW profiles.
+
+%---------- code ----------
+\begin{minted}{python}
+>>> # select a subset
+>>> here = (sig > 15) & (redshift < 0.5)
+>>> sig[here].shape
+(15,)
+>>> z = redshift[here]
+>>> n200 = richness[here]
+>>> 
+>>> import clusterlensing
+>>> c = clusterlensing.ClusterEnsemble(z)
+>>> c.n200 = n200
+>>> c.dataframe.head()
+     z  n200          m200      r200      c200
+         delta_c        rs
+0  0.4   181  5.897552e+14  1.531367  3.966101
+     5173.016417  0.386114
+1  0.3   420  1.916332e+15  2.357815  3.658237
+     4332.615805  0.644522
+2  0.4   176  5.670737e+14  1.511478  3.980218
+     5213.746469  0.379747
+3  0.3   113  3.049521e+14  1.277703  4.341779
+     6324.420397  0.294281
+4  0.4   162  5.049435e+14  1.454129  4.022285
+     5336.272412  0.361518
+>>>
+>>> rbins = np.logspace(np.log10(0.1),
+>>>                     np.log10(10.0), num=20)
+>>> c.calc_nfw(rbins)
+\end{minted}
+\label{3dmf2df}
+%----------------------------
+
 
 Next we import the \code{matplotlib} and \code{seaborn} libraries and configure some settings to make our plots more readable. The first plot we create with the commands below presents the $\Sigma(R)$ profiles for every one of these 15 clusters, and is given in \cref{f1}.
 %---------- code ----------
@@ -574,51 +627,6 @@ Next we import the \code{matplotlib} and \code{seaborn} libraries and configure 
 
 \end{minted}
 %----------------------------
-
-%---------- code ----------
-\begin{listing*}
-\begin{minted}{python}
->>> import numpy as np
->>> data = np.loadtxt("Clusters_W1.dat")
->>> data.shape
-(10745, 5)
->>> data[0:4, :]  # print first 4 clusters
-array([[ 34.8023, -7.01005, 0.3, 4.435, 10.],
-       [ 34.9425, -7.38996, 0.5, 4.545, 21.],
-       [ 34.8651, -6.69449, 0.5, 3.858, 6.],
-       [ 34.6224, -7.32768, 0.5, 3.619, 8.]])
->>>
->>> redshift = data[:, 2]
->>> sig = data[:, 3]
->>> richness = data[:, 4]
->>>
->>> # select a subset
->>> here = (sig > 15) & (redshift < 0.5)
->>> sig[here].shape
-(15,)
->>> z = redshift[here]
->>> n200 = richness[here]
->>> 
->>> import clusterlensing
->>> c = clusterlensing.ClusterEnsemble(z)
->>> c.n200 = n200
->>> c.dataframe.head()
-     z  n200          m200      r200      c200      delta_c        rs
-0  0.4   181  5.897552e+14  1.531367  3.966101  5173.016417  0.386114
-1  0.3   420  1.916332e+15  2.357815  3.658237  4332.615805  0.644522
-2  0.4   176  5.670737e+14  1.511478  3.980218  5213.746469  0.379747
-3  0.3   113  3.049521e+14  1.277703  4.341779  6324.420397  0.294281
-4  0.4   162  5.049435e+14  1.454129  4.022285  5336.272412  0.361518
-
->>> rbins = np.logspace(np.log10(0.1),
->>>                     np.log10(10.0), num=20)
->>> c.calc_nfw(rbins)
-\end{minted}
-\caption{Selecting a subset of the CFHTLenS galaxy cluster dataset and calculating the NFW profiles.}
-\label{3dmf2df}
-\end{listing*}
-%----------------------------
-
 
 \begin{figure}
 \epsscale{1.2}

--- a/clusterlensing.tex
+++ b/clusterlensing.tex
@@ -149,7 +149,7 @@ where  $g(x) = $
 Running \code{sigma_nfw()} or \code{deltasigma_nfw()}, with only a specification of halo properties \code{rs}, \code{delta_c}, \code{rho_crit}, and radial bins \code{rbins}, will lead to the calculation of halo profiles according to Equations \ref{sigma} and \ref{dsigma} outlined above.
 
 %---------- code ----------
-\begin{minted}{python}
+\begin{minted}[fontsize=\footnotesize, frame=lines, framesep=2mm, baselinestretch=1.1]{python}
 >>> from clusterlensing import SurfaceMassDensity
 >>> rbins = [0.1, 0.5, 1.0, 2.0, 4.0] # Mpc
 >>> smd = SurfaceMassDensity(rs=[0.1],
@@ -176,7 +176,7 @@ P(R_{off})=\frac{R_{off}}{\sigma_{off}^2}\ \mathrm{exp}\bigg[-\frac{1}{2}\bigg(\
 The parameter \code{offsets} is equivalent to $\sigma_{off}$ in this equation.
 
 %---------- code ----------
-\begin{minted}{python}
+\begin{minted}[fontsize=\footnotesize, frame=lines, framesep=2mm, baselinestretch=1.1]{python}
 >>> from clusterlensing import SurfaceMassDensity
 >>> rbins = [0.1, 0.5, 1.0, 2.0, 4.0]
 >>> # single miscentered halo profile
@@ -216,7 +216,7 @@ The miscentered surface mass density profiles are given by the centered profiles
 Here $r = \sqrt{R^2+R_{off}^2-2RR_{off}\cos(\theta)}$ and $\theta$ is the azimuthal angle \citep{Yang06}. The $\Delta\Sigma^\mathrm{off}$ profile is calculated from $\Sigma^\mathrm{off}$, in analogy with Equations \ref{dsigma} and \ref{sigbar}.
 
 %---------- code ----------
-\begin{minted}{python}
+\begin{minted}[fontsize=\footnotesize, frame=lines, framesep=2mm, baselinestretch=1.1]{python}
 >>> from clusterlensing import SurfaceMassDensity
 >>> rbins = [0.1, 0.5, 1.0, 2.0, 4.0]
 >>> # perfectly centered DeltaSigma profile
@@ -267,7 +267,7 @@ b = -0.101 + 0.206 z.
 The above three equations map to Equations 7, 11, and 10, respectively in \citet{Dutton14}. The values in these expressions were determined from simulations of halos between $0 < z < 5$, spanning over 5 orders of magnitude in mass, and were shown to match observational measurements of low-redshift galaxies and clusters \citep{Dutton14}. This concentration-mass relation is the default one used by the \code{clusters} module, discussed in Section \ref{clusters}.
 
 %---------- code ----------
-\begin{minted}{python}
+\begin{minted}[fontsize=\footnotesize, frame=lines, framesep=2mm, baselinestretch=1.1]{python}
 >>> from clusterlensing import cofm
 >>> # single 10**14 Msun halo at z=1
 >>> cofm.c_DuttonMaccio(0.1, 1e14)
@@ -292,7 +292,7 @@ M_{pivot} = 2 \times 10^{12}\ h^{-1} M_\odot.
 Equation \ref{c_Duffy} above corresponds to Equation 4 in \citet{Duffy08}. The values for $A$, $B$, and $C$ can be found in Table 1 of that work, where they are specific to the ``full'' (relaxed and unrelaxed) sample of simulated NFW halos, spanning the redshift range $0 < z < 2$. $M_{pivot}$ can be found in the caption of their Table 1 as well. One caveat with this relation is that the cosmology used in creating the \citet{Duffy08} simulations was that of the now outdated WMAP5 experiment \citep{WMAP5}.
 
 %---------- code ----------
-\begin{minted}{python}
+\begin{minted}[fontsize=\footnotesize, frame=lines, framesep=2mm, baselinestretch=1.1]{python}
 >>> from clusterlensing import cofm
 >>> # default cosmology (h=0.6777)
 >>> cofm.c_Duffy([0.1, 0.5], [1e14, 1e15])
@@ -338,7 +338,7 @@ c_{min}(x_p) = 3.681 + 1.352 \bigg[ \frac{1}{\pi} \arctan[6.948 (x_p - 0.424)] +
 \end{equation}
 In order of appearance above, beginning with our Equation \ref{c_Prada}, these equations correspond to Equations 14-17, 13, 23a, 23b, 12, 18a, 18b, 19, 20 in \citet{Prada12}. The numerical values in these equations were obtained empirically from the simulations described in that work.
 %---------- code ----------
-\begin{minted}{python}
+\begin{minted}[fontsize=\footnotesize, frame=lines, framesep=2mm, baselinestretch=1.1]{python}
 >>> from clusterlensing import cofm
 >>> cofm.c_Prada([0.1, 0.5], [1e14, 1e15])
 array([ 5.06733941,  5.99897362])
@@ -360,7 +360,7 @@ The function \code{calc_delta_c()} takes a single input parameter, the cluster c
 \end{equation}
 Both input and output are dimensionless here. For example, to convert a concentration value of $c_{200} = 5$ to $\delta_c$, you could do:
 %---------- code ----------
-\begin{minted}{python}
+\begin{minted}[fontsize=\footnotesize, frame=lines, framesep=2mm, baselinestretch=1.1]{python}
 >>> from clusterlensing.clusters import calc_delta_c
 >>> calc_delta_c(5)
 8694.8101906193315
@@ -374,7 +374,7 @@ M_{200} = M_0 \left( \frac{N_{200}}{20} \right) ^ \beta.
 Here $M_0$ is the normalization, which defaults to $2.7 \times 10^{13}$, but can be changed in the call to either function by setting the \code{norm} keyword argument. The power-law slope $\beta = 1.4$ by default, but can be set by specifying the optional \code{slope} input parameter. When these functions are invoked by the \code{ClusterEnsemble()} class, they are applied to the particular mass definition $M_{200}$, and assume units of $M_{\odot}$. However the functions themselves do not assume a mass definition or unit, and can be generalized to any parameter (or type of richness) that has a power-law relationship with mass.
 
 %---------- code ----------
-\begin{minted}{python}
+\begin{minted}[fontsize=\footnotesize, frame=lines, framesep=2mm, baselinestretch=1.1]{python}
 >>> from clusterlensing.clusters import \
 >>> mass_to_richness, richness_to_mass
 >>> richness_to_mass(50)
@@ -390,7 +390,7 @@ Here $M_0$ is the normalization, which defaults to $2.7 \times 10^{13}$, but can
 The \code{ClusterEnsemble()} class creates, modifies and tracks a Pandas DataFrame containing the properties and attributes of many galaxy clusters at once. When given a new or updated cluster property, it calculates and updates all dependent cluster properties, treating each cluster (row) in the DataFrame as an individual object. This makes it easy to calculate the $\Sigma(R)$ and $\Delta\Sigma(R)$ weak lensing profiles for many different mass clusters at different redshifts, with a single command. In contrast to using the \code{SurfaceMassDensity()} class discussed in Section \ref{nfw}, the user only needs to specify the cluster redshifts and either of the mass or richness. If richness is supplied, then mass is calculated from it, assuming the form of Equation \ref{massrich} (which is customizable); if mass is specified instead, than the inverse relation is used to calculate richness. In either case the changes are propagated to any dependent variables.
 
 %---------- code ----------
-\begin{minted}{python}
+\begin{minted}[fontsize=\footnotesize, frame=lines, framesep=2mm, baselinestretch=1.1]{python}
 >>> from clusterlensing import ClusterEnsemble
 >>> z = [0.1,0.2,0.3]
 >>> c = ClusterEnsemble(z)
@@ -425,7 +425,7 @@ The \code{ClusterEnsemble()} class creates, modifies and tracks a Pandas DataFra
 The above examples also demonstrate that cluster masses are converted to concentrations and to characteristic halo overdensities. This assumes the default mass-concentration relation of the \code{c_DuttonMaccio()} form, or the user can instead specify another of the relations by setting the keyword \code{cm="Prada"} or \code{cm="Duffy"}, when the \code{ClusterEnsemble()} object is instantiated. Cosmology can also be specified upon instantiation, by setting the \code{cosmology} keyword to be any \code{astropy.cosmology} object that has an \code{h} and a \code{Om0} attribute. If not specified explicitly, the default cosmological model used is \code{astropy.cosmology.Planck13}. Here is an example of creating a \code{ClusterEnsemble()} object that uses the WMAP5 cosmology \citep{WMAP5} and the \citet{Duffy08} concentration:
 \pagebreak
 %---------- code ----------
-\begin{minted}{python}
+\begin{minted}[fontsize=\footnotesize, frame=lines, framesep=2mm, baselinestretch=1.1]{python}
 >>> from astropy.cosmology import WMAP5 as cosmo
 >>> c = ClusterEnsemble(z, cm="Duffy",
 >>>                     cosmology=cosmo)
@@ -443,7 +443,7 @@ The above examples also demonstrate that cluster masses are converted to concent
 %----------------------------
 
 Instead of using the \code{dataframe} attribute, which retrieves the Pandas DataFrame object itself, it might be useful to use the \code{show()} method, which prints additional information to the screen, including assumptions of the mass-richness relation:%---------- code ----------
-\begin{minted}{python}
+\begin{minted}[fontsize=\footnotesize, frame=lines, framesep=2mm, baselinestretch=1.1]{python}
 >>> c.show()
 
 Cluster Ensemble:
@@ -490,7 +490,7 @@ The last example also demonstrates how the slope or normalization of the mass-ri
 
 Then all the ingredients are in place to calculate halo profiles by invoking the \code{calc_nfw()} method, which interfaces to the \code{sigma_nfw()} and \code{deltasigma_nfw()} methods of the \code{SurfaceMassDensity()} class, and passes it the required inputs $\{ r_s, \rho_{crit}, \delta_c \}$ for all the clusters behind the scenes. The value of $\rho_{crit}$ is calculated at every cluster redshift using the (default \code{astropy.cosmology.Planck13} or user-specified) cosmological model. The user must specify the desired radial bins \code{rbins} in Mpc.
 %---------- code ----------
-\begin{minted}{python}
+\begin{minted}[fontsize=\footnotesize, frame=lines, framesep=2mm, baselinestretch=1.1]{python}
 >>> import numpy as np
 >>> # create some logarithmic bins:
 >>> rmin, rmax = 0.1, 5.  # Mpc
@@ -521,7 +521,7 @@ Then all the ingredients are in place to calculate halo profiles by invoking the
 
 Similar to the direct use of \code{SurfaceMassDensity()}, discussed in Section \ref{nfw}, the miscentered profiles can be calculated from the \code{calc_nfw()} method, by supplying the optional \code{offsets} keyword with an array-like object of length equal to the number of clusters, where each element is the width of the offset distribution in Mpc ($\sigma_{off}$ in Equation \ref{PofR}).
 %---------- code ----------
-\begin{minted}{python}
+\begin{minted}[fontsize=\footnotesize, frame=lines, framesep=2mm, baselinestretch=1.1]{python}
 >>> c.calc_nfw(rbins=rbins, offsets=[0.3,0.3,0.3])
 >>> # the offset sigma profile is now:
 >>> c.sigma_nfw
@@ -543,7 +543,7 @@ Although \code{SurfaceMassDensity()} from the \code{nfw} module, and \code{Clust
 \label{ex}
 As an example use case, we take the Canada-France-Hawaii Telescope Lensing Survey \citep[CFHTLenS;][]{Heymans12, Erben13} public galaxy cluster catalog, which is available on Zenodo\footnote{\url{http://dx.doi.org/10.5281/zenodo.51291}} \citep{3DMFcatalog}. This dataset was previously explored using a pre-release version of the \code{cluster-lensing} software in \citet{Ford14, Ford15}. The W1 field of this survey contains 10,745 galaxy cluster candidates in the redshift range $0.2 \le z \le 0.9$:
 %---------- code ----------
-\begin{minted}{python}
+\begin{minted}[fontsize=\footnotesize, frame=lines, framesep=2mm, baselinestretch=1.1]{python}
 >>> import numpy as np
 >>> data = np.loadtxt("Clusters_W1.dat")
 >>> data.shape
@@ -563,7 +563,7 @@ array([[ 34.8023, -7.01005, 0.3, 4.435, 10.],
 We select a subset of the lower redshift clusters that were detected at high significance. Then we import \code{clusterlensing} to create a dataframe of the cluster properties, of which we just print the first several, and calculate the NFW profiles.
 
 %---------- code ----------
-\begin{minted}{python}
+\begin{minted}[fontsize=\footnotesize, frame=lines, framesep=2mm, baselinestretch=1.1]{python}
 >>> # select a subset
 >>> here = (sig > 15) & (redshift < 0.5)
 >>> sig[here].shape
@@ -598,7 +598,7 @@ We select a subset of the lower redshift clusters that were detected at high sig
 
 Next we import the \code{matplotlib} and \code{seaborn} libraries and configure some settings to make our plots more readable. The first plot we create with the commands below presents the $\Sigma(R)$ profiles for every one of these 15 clusters, and is given in \cref{f1}.
 %---------- code ----------
-\begin{minted}{python}
+\begin{minted}[fontsize=\footnotesize, frame=lines, framesep=2mm, baselinestretch=1.1]{python}
 
 >>> import matplotlib.pyplot as plt
 >>> import seaborn as sns; sns.set()
@@ -639,7 +639,7 @@ Next we import the \code{matplotlib} and \code{seaborn} libraries and configure 
 If we had made a stacked measurement of the shear or magnification profile of these clusters, then we would want to know what the average profile of the stack looks like. Since we already have the individual profiles, we just need to calculate the mean across the 0$^\mathrm{th}$ axis of the \code{sigma_nfw} and \code{deltasigma_nfw} attribute arrays. The plot of these average profiles is given in \cref{f2}.
 
 %---------- code ----------
-\begin{minted}{python}
+\begin{minted}[fontsize=\footnotesize, frame=lines, framesep=2mm, baselinestretch=1.1]{python}
 
 >>> sigma = c.sigma_nfw.mean(axis=0)
 >>> dsigma = c.deltasigma_nfw.mean(axis=0)
@@ -668,7 +668,7 @@ If we had made a stacked measurement of the shear or magnification profile of th
 Finally, we may want to investigate whether cluster miscentering has a significant effect on our sample. We would calculate the miscentered profiles, given in \cref{f3}, which could be compared to the centered profiles in \cref{f2} to see which is a better fit to our measurement. Below we will assume that the miscentering offset distribution peaks at 0.1 Mpc.
 \pagebreak
 %---------- code ----------
-\begin{minted}{python}
+\begin{minted}[fontsize=\footnotesize, frame=lines, framesep=2mm, baselinestretch=1.1]{python}
 
 >>> offsets = np.ones(c.z.shape[0]) * 0.1
 >>> c.calc_nfw(rbins, offsets=offsets)

--- a/clusterlensing.tex
+++ b/clusterlensing.tex
@@ -423,7 +423,7 @@ The \code{ClusterEnsemble()} class creates, modifies and tracks a Pandas DataFra
 %----------------------------
 
 The above examples also demonstrate that cluster masses are converted to concentrations and to characteristic halo overdensities. This assumes the default mass-concentration relation of the \code{c_DuttonMaccio()} form, or the user can instead specify another of the relations by setting the keyword \code{cm="Prada"} or \code{cm="Duffy"}, when the \code{ClusterEnsemble()} object is instantiated. Cosmology can also be specified upon instantiation, by setting the \code{cosmology} keyword to be any \code{astropy.cosmology} object that has an \code{h} and a \code{Om0} attribute. If not specified explicitly, the default cosmological model used is \code{astropy.cosmology.Planck13}. Here is an example of creating a \code{ClusterEnsemble()} object that uses the WMAP5 cosmology \citep{WMAP5} and the \citet{Duffy08} concentration:
-\newpage
+\pagebreak
 %---------- code ----------
 \begin{minted}{python}
 >>> from astropy.cosmology import WMAP5 as cosmo
@@ -666,7 +666,7 @@ If we had made a stacked measurement of the shear or magnification profile of th
 \end{figure}
 
 Finally, we may want to investigate whether cluster miscentering has a significant effect on our sample. We would calculate the miscentered profiles, given in \cref{f3}, which could be compared to the centered profiles in \cref{f2} to see which is a better fit to our measurement. Below we will assume that the miscentering offset distribution peaks at 0.1 Mpc.
-\newpage
+\pagebreak
 %---------- code ----------
 \begin{minted}{python}
 

--- a/clusterlensing.tex
+++ b/clusterlensing.tex
@@ -11,10 +11,10 @@
 
 \usepackage{minted}
 %\usemintedstyle{trac}
-\setminted{fontsize=\footnotesize,
-		frame=lines,
-		framesep=2mm,
-		baselinestretch=1.1}
+%\setminted{fontsize=\footnotesize,
+%		frame=lines,
+%		framesep=2mm,
+%		baselinestretch=1.1}
 
 \usepackage{listings}
 \lstdefinestyle{codeintext}{language=Python, basicstyle=\ttfamily} %normal size font for in text


### PR DESCRIPTION
For some reason the `\setminted` command was causing the Travis build to fail or error (although it builds fine locally). Removing that line, and copying the set of options it was supposed to set to every block of code in the document solved the problem, but is not ideal. 
